### PR TITLE
Validate HTTP status code range in HttpProblem.Builder

### DIFF
--- a/runtime/src/main/java/io/quarkiverse/httpproblem/HttpProblem.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/HttpProblem.java
@@ -181,8 +181,7 @@ public class HttpProblem extends RuntimeException {
 
         public Builder withStatus(Response.StatusType status) {
             Objects.requireNonNull(status);
-            this.statusCode = status.getStatusCode();
-            return this;
+            return withStatus(status.getStatusCode());
         }
 
         public Builder withStatus(int statusCode) {

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/HttpProblem.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/HttpProblem.java
@@ -186,6 +186,9 @@ public class HttpProblem extends RuntimeException {
         }
 
         public Builder withStatus(int statusCode) {
+            if (statusCode < 100 || statusCode > 599) {
+                throw new IllegalArgumentException("HTTP status code must be between 100 and 599, got: " + statusCode);
+            }
             this.statusCode = statusCode;
             return this;
         }

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/HttpProblemTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/HttpProblemTest.java
@@ -50,4 +50,19 @@ class HttpProblemTest {
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
+    @ParameterizedTest
+    @ValueSource(ints = { 100, 200, 301, 400, 404, 500, 599 })
+    void withStatusShouldAcceptValidStatusCodes(int statusCode) {
+        HttpProblem problem = HttpProblem.builder().withStatus(statusCode).build();
+        assertThat(problem.getStatusCode()).isEqualTo(statusCode);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { -1, 0, 99, 600, 1000, Integer.MAX_VALUE, Integer.MIN_VALUE })
+    void withStatusShouldRejectInvalidStatusCodes(int statusCode) {
+        assertThatThrownBy(() -> HttpProblem.builder().withStatus(statusCode))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(String.valueOf(statusCode));
+    }
+
 }


### PR DESCRIPTION
`HttpProblem.Builder.withStatus(int)` accepts any integer without validation, meaning values like 0, -1, or 99999 flow through to serialization and produce invalid RFC 9457 responses. This adds a range check (100-599) that throws `IllegalArgumentException` for out-of-range codes, catching the error at build time rather than producing a malformed response at runtime.

The `withStatus(Response.StatusType)` overload now delegates to the validated int overload for consistent validation across both entry points.

Closes #659