### PR TITLE
Make status code validation range configurable

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/httpproblem/deployment/ProblemProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/httpproblem/deployment/ProblemProcessor.java
@@ -256,6 +256,31 @@ public class ProblemProcessor {
 
     @Record(STATIC_INIT)
     @BuildStep
+    void configureStatusCodeRange(ProblemRecorder recorder, ProblemRuntimeFixedConfig config) {
+        int min = config.statusCode().min();
+        int max = config.statusCode().max();
+        validateStatusCodeRange(min, max);
+        recorder.configureStatusCodeRange(min, max);
+    }
+
+    static void validateStatusCodeRange(int min, int max) {
+        if (min > max) {
+            throw new ConfigurationException(
+                    "quarkus.http-problem.status-code.min (" + min
+                            + ") must be <= quarkus.http-problem.status-code.max (" + max + ")");
+        }
+        if (min < 100) {
+            throw new ConfigurationException(
+                    "quarkus.http-problem.status-code.min (" + min + ") must be >= 100");
+        }
+        if (max > 999) {
+            throw new ConfigurationException(
+                    "quarkus.http-problem.status-code.max (" + max + ") must be <= 999");
+        }
+    }
+
+    @Record(STATIC_INIT)
+    @BuildStep
     SyntheticBeanBuildItem setupLogging(ProblemRecorder recorder, ProblemBuildConfig config) {
         ProblemBuildConfig.LoggingConfig logging = config.logging();
         if (!logging.enabled()) {

--- a/deployment/src/test/java/io/quarkiverse/httpproblem/deployment/ProblemProcessorTest.java
+++ b/deployment/src/test/java/io/quarkiverse/httpproblem/deployment/ProblemProcessorTest.java
@@ -83,4 +83,36 @@ class ProblemProcessorTest {
                 .isTrue();
     }
 
+    @Test
+    void validateStatusCodeRangeShouldPassForDefaults() {
+        ProblemProcessor.validateStatusCodeRange(100, 599);
+    }
+
+    @Test
+    void validateStatusCodeRangeShouldPassForExtendedRange() {
+        ProblemProcessor.validateStatusCodeRange(100, 999);
+    }
+
+    @Test
+    void validateStatusCodeRangeShouldFailWhenMinGreaterThanMax() {
+        assertThatThrownBy(() -> ProblemProcessor.validateStatusCodeRange(600, 500))
+                .isInstanceOf(ConfigurationException.class)
+                .hasMessageContaining("min")
+                .hasMessageContaining("max");
+    }
+
+    @Test
+    void validateStatusCodeRangeShouldFailWhenMinBelow100() {
+        assertThatThrownBy(() -> ProblemProcessor.validateStatusCodeRange(50, 599))
+                .isInstanceOf(ConfigurationException.class)
+                .hasMessageContaining("100");
+    }
+
+    @Test
+    void validateStatusCodeRangeShouldFailWhenMaxAbove999() {
+        assertThatThrownBy(() -> ProblemProcessor.validateStatusCodeRange(100, 1000))
+                .isInstanceOf(ConfigurationException.class)
+                .hasMessageContaining("999");
+    }
+
 }

--- a/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457StandardMembersTest.java
+++ b/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457StandardMembersTest.java
@@ -154,4 +154,15 @@ class Rfc9457StandardMembersTest {
                 .then()
                 .body("instance", equalTo("/throw/rfc9457/without-instance"));
     }
+
+    @ParameterizedTest(name = "RFC 9110 - out-of-range status code {0} should be rejected")
+    @ValueSource(ints = { 0, 99, 600, 1000 })
+    void outOfRangeStatusCodeShouldBeRejected(int status) {
+        given()
+                .queryParam("status", status)
+                .get("/throw/rfc9457/with-status")
+                .then()
+                .statusCode(INTERNAL_SERVER_ERROR.getStatusCode())
+                .body("status", equalTo(INTERNAL_SERVER_ERROR.getStatusCode()));
+    }
 }

--- a/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457StatusCodeRangeNativeIT.java
+++ b/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457StatusCodeRangeNativeIT.java
@@ -1,0 +1,7 @@
+package io.quarkiverse.httpproblem;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+class Rfc9457StatusCodeRangeNativeIT extends Rfc9457StatusCodeRangeTest {
+}

--- a/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457StatusCodeRangeTest.java
+++ b/integration-test/tck/src/test/java/io/quarkiverse/httpproblem/Rfc9457StatusCodeRangeTest.java
@@ -1,0 +1,42 @@
+package io.quarkiverse.httpproblem;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.equalTo;
+
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@QuarkusTest
+@TestProfile(Rfc9457StatusCodeRangeTest.ExtendedRange.class)
+class Rfc9457StatusCodeRangeTest {
+
+    static {
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+    }
+
+    @ParameterizedTest(name = "Extended range - non-standard status code {0} should be accepted when max=999")
+    @ValueSource(ints = { 600, 783, 999 })
+    @DisplayName("Non-standard status codes should be accepted with extended range configuration")
+    void nonStandardStatusCodeShouldBeAcceptedWithExtendedRange(int status) {
+        given()
+                .queryParam("status", status)
+                .get("/throw/rfc9457/with-status")
+                .then()
+                .statusCode(status)
+                .body("status", equalTo(status));
+    }
+
+    public static class ExtendedRange implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("quarkus.http-problem.status-code.max", "999");
+        }
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/HttpProblem.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/HttpProblem.java
@@ -26,6 +26,14 @@ public class HttpProblem extends RuntimeException {
 
     public static final MediaType MEDIA_TYPE = new MediaType("application", "problem+json");
 
+    static int statusCodeMin = 100;
+    static int statusCodeMax = 599;
+
+    public static void configureStatusCodeRange(int min, int max) {
+        statusCodeMin = min;
+        statusCodeMax = max;
+    }
+
     @Schema(description = "A optional URI reference that identifies the problem type", examples = "https://example.com/errors/not-found")
     private final URI type;
 
@@ -185,8 +193,10 @@ public class HttpProblem extends RuntimeException {
         }
 
         public Builder withStatus(int statusCode) {
-            if (statusCode < 100 || statusCode > 599) {
-                throw new IllegalArgumentException("HTTP status code must be between 100 and 599, got: " + statusCode);
+            if (statusCode < statusCodeMin || statusCode > statusCodeMax) {
+                throw new IllegalArgumentException(
+                        "HTTP status code must be between " + statusCodeMin + " and " + statusCodeMax
+                                + ", got: " + statusCode);
             }
             this.statusCode = statusCode;
             return this;

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/ProblemRuntimeFixedConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/ProblemRuntimeFixedConfig.java
@@ -27,10 +27,34 @@ public interface ProblemRuntimeFixedConfig {
     boolean includeDetails();
 
     /**
+     * Status code validation range configuration.
+     */
+    @WithName("status-code")
+    StatusCodeConfig statusCode();
+
+    /**
      * Constraint violation configuration.
      */
     @WithName("constraint-violation")
     ConstraintViolationConfig constraintViolation();
+
+    interface StatusCodeConfig {
+
+        /**
+         * Minimum allowed HTTP status code (inclusive).
+         * RFC 9110 defines 100 as the lowest valid status code.
+         */
+        @WithDefault("100")
+        int min();
+
+        /**
+         * Maximum allowed HTTP status code (inclusive).
+         * RFC 9110 defines 599 as the highest valid status code.
+         * Set to 999 to allow non-standard codes used by some APIs.
+         */
+        @WithDefault("599")
+        int max();
+    }
 
     interface ConstraintViolationConfig {
 

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/postprocessing/ProblemRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/postprocessing/ProblemRecorder.java
@@ -3,6 +3,7 @@ package io.quarkiverse.httpproblem.postprocessing;
 import java.util.List;
 import java.util.Map;
 
+import io.quarkiverse.httpproblem.HttpProblem;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 
@@ -13,6 +14,10 @@ public class ProblemRecorder {
             List<String> stackTracePatterns) {
         ProblemLoggingConfig config = new ProblemLoggingConfig(levels, stackTracePatterns);
         return new RuntimeValue<>(new ProblemLogger(config));
+    }
+
+    public void configureStatusCodeRange(int min, int max) {
+        HttpProblem.configureStatusCodeRange(min, max);
     }
 
 }

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/HttpProblemTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/HttpProblemTest.java
@@ -6,11 +6,17 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import jakarta.ws.rs.core.Response;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class HttpProblemTest {
+
+    @AfterEach
+    void resetStatusCodeRange() {
+        HttpProblem.configureStatusCodeRange(100, 599);
+    }
 
     @Test
     void builderShouldPassAllFields() {
@@ -63,6 +69,35 @@ class HttpProblemTest {
         assertThatThrownBy(() -> HttpProblem.builder().withStatus(statusCode))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining(String.valueOf(statusCode));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { 600, 783, 999 })
+    void withStatusShouldAcceptExtendedRangeWhenConfigured(int statusCode) {
+        HttpProblem.configureStatusCodeRange(100, 999);
+        HttpProblem problem = HttpProblem.builder().withStatus(statusCode).build();
+        assertThat(problem.getStatusCode()).isEqualTo(statusCode);
+    }
+
+    @Test
+    void withStatusShouldRejectCodesOutsideConfiguredRange() {
+        HttpProblem.configureStatusCodeRange(200, 499);
+
+        assertThatThrownBy(() -> HttpProblem.builder().withStatus(100))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("200")
+                .hasMessageContaining("499");
+
+        assertThatThrownBy(() -> HttpProblem.builder().withStatus(500))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("200")
+                .hasMessageContaining("499");
+    }
+
+    @Test
+    void defaultStatusCodeRangeShouldBeSpecCompliant() {
+        assertThat(HttpProblem.statusCodeMin).isEqualTo(100);
+        assertThat(HttpProblem.statusCodeMax).isEqualTo(599);
     }
 
 }


### PR DESCRIPTION
PR #660 added hard-coded 100-599 validation to `HttpProblem.Builder.withStatus(int)`. Some real-world APIs use non-standard status codes outside this range (e.g. LinkedIn 999, Shopify 783), so the range should be configurable rather than fixed.

This adds two config properties:

```properties
quarkus.http-problem.status-code.min=100  # default, must be >= 100
quarkus.http-problem.status-code.max=599  # default (RFC 9110), set to 999 for non-standard APIs
```

The defaults enforce RFC 9110 compliance out of the box. Invalid config (min > max, min < 100, max > 999) fails the build with a clear `ConfigurationException`.

The config reaches the static `HttpProblem.Builder` via the existing recorder + STATIC_INIT pattern (same as `ProblemLogger`). The static fields have safe defaults so the Builder works in plain unit tests without Quarkus.

TCK tests verify both the default range enforcement (out-of-range codes produce a 500) and the extended range behavior via a `QuarkusTestProfile` override.

Closes #661