### PR TITLE
Sanitize user-supplied values in ProblemLogger to prevent log injection

### DIFF
--- a/runtime/src/main/java/io/quarkiverse/httpproblem/postprocessing/ProblemLogger.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/postprocessing/ProblemLogger.java
@@ -2,6 +2,7 @@ package io.quarkiverse.httpproblem.postprocessing;
 
 import java.util.Map;
 import java.util.Objects;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -10,6 +11,8 @@ import org.jboss.logging.Logger;
 import io.quarkiverse.httpproblem.HttpProblem;
 
 public class ProblemLogger implements ProblemPostProcessor {
+
+    private static final Pattern CONTROL_CHARS = Pattern.compile("\\e\\[[0-9;]*[a-zA-Z]|[\\x00-\\x1f\\x7f]");
 
     private final Logger logger;
     private final ProblemLoggingConfig config;
@@ -39,8 +42,8 @@ public class ProblemLogger implements ProblemPostProcessor {
     private String serialize(HttpProblem problem) {
         Stream<String> basicFields = Stream.of(
                 "status=" + problem.getStatusCode(),
-                problem.getTitle() == null ? null : "title=\"" + problem.getTitle() + "\"",
-                problem.getDetail() == null ? null : "detail=\"" + problem.getDetail() + "\"",
+                problem.getTitle() == null ? null : "title=\"" + sanitize(problem.getTitle()) + "\"",
+                problem.getDetail() == null ? null : "detail=\"" + sanitize(problem.getDetail()) + "\"",
                 problem.getInstance() == null ? null : "instance=\"" + problem.getInstance() + "\"",
                 problem.getType() == null ? null : "type=" + problem.getType());
 
@@ -57,11 +60,18 @@ public class ProblemLogger implements ProblemPostProcessor {
         if (value == null) {
             serializedValue = "null";
         } else if (value instanceof String) {
-            serializedValue = "\"" + value + "\"";
+            serializedValue = "\"" + sanitize((String) value) + "\"";
         } else {
-            serializedValue = value.toString();
+            serializedValue = sanitize(value.toString());
         }
-        return param.getKey() + "=" + serializedValue;
+        return sanitize(param.getKey()) + "=" + serializedValue;
+    }
+
+    static String sanitize(String value) {
+        if (value == null) {
+            return null;
+        }
+        return CONTROL_CHARS.matcher(value).replaceAll("_");
     }
 
     @Override

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/postprocessing/ProblemLoggerTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/postprocessing/ProblemLoggerTest.java
@@ -253,6 +253,19 @@ class ProblemLoggerTest {
     }
 
     @Test
+    void shouldSanitizeParameterKeys() {
+        HttpProblem problem = HttpProblem.builder()
+                .withTitle("error")
+                .withStatus(BAD_REQUEST)
+                .with("bad\nkey", "value")
+                .build();
+
+        processor.apply(problem, simpleContext());
+
+        verify(logger).info("status=400, title=\"error\", bad_key=\"value\"");
+    }
+
+    @Test
     void sanitizeShouldReturnNullForNull() {
         assertThat(ProblemLogger.sanitize(null)).isNull();
     }

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/postprocessing/ProblemLoggerTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/postprocessing/ProblemLoggerTest.java
@@ -5,6 +5,7 @@ import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
 import static jakarta.ws.rs.core.Response.Status.FORBIDDEN;
 import static jakarta.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import static jakarta.ws.rs.core.Response.Status.UNAUTHORIZED;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -198,6 +199,72 @@ class ProblemLoggerTest {
         verify(logger, never()).error(anyString());
         verify(logger, never()).debug(anyString());
         verify(logger, never()).trace(anyString());
+    }
+
+    @Test
+    void shouldSanitizeNewlinesInTitle() {
+        HttpProblem problem = HttpProblem.builder()
+                .withTitle("legit\nINFO [fake] forged log line")
+                .withStatus(BAD_REQUEST)
+                .build();
+
+        processor.apply(problem, simpleContext());
+
+        verify(logger).info("status=400, title=\"legit_INFO [fake] forged log line\"");
+    }
+
+    @Test
+    void shouldSanitizeNewlinesInDetail() {
+        HttpProblem problem = HttpProblem.builder()
+                .withTitle("error")
+                .withDetail("line1\r\nline2")
+                .withStatus(BAD_REQUEST)
+                .build();
+
+        processor.apply(problem, simpleContext());
+
+        verify(logger).info("status=400, title=\"error\", detail=\"line1__line2\"");
+    }
+
+    @Test
+    void shouldSanitizeAnsiEscapesInDetail() {
+        HttpProblem problem = HttpProblem.builder()
+                .withTitle("error")
+                .withDetail("normal [31mred text[0m end")
+                .withStatus(BAD_REQUEST)
+                .build();
+
+        processor.apply(problem, simpleContext());
+
+        verify(logger).info("status=400, title=\"error\", detail=\"normal _red text_ end\"");
+    }
+
+    @Test
+    void shouldSanitizeCustomParameterValues() {
+        HttpProblem problem = HttpProblem.builder()
+                .withTitle("error")
+                .withStatus(BAD_REQUEST)
+                .with("injected", "value\nERROR [fake] forged")
+                .build();
+
+        processor.apply(problem, simpleContext());
+
+        verify(logger).info("status=400, title=\"error\", injected=\"value_ERROR [fake] forged\"");
+    }
+
+    @Test
+    void sanitizeShouldReturnNullForNull() {
+        assertThat(ProblemLogger.sanitize(null)).isNull();
+    }
+
+    @Test
+    void sanitizeShouldPassThroughCleanStrings() {
+        assertThat(ProblemLogger.sanitize("clean string 123")).isEqualTo("clean string 123");
+    }
+
+    @Test
+    void sanitizeShouldReplaceTabsAndOtherControlChars() {
+        assertThat(ProblemLogger.sanitize("a\tb c")).isEqualTo("a_b_c");
     }
 
 }


### PR DESCRIPTION
\`ProblemLogger.serialize()\` directly concatenates user-supplied values (title, detail, parameter keys and values) into log messages without sanitizing control characters. A crafted detail string containing newlines can forge extra log lines that look like legitimate entries, and ANSI escape sequences can alter terminal output for anyone reading the logs.

This adds a \`sanitize()\` method that replaces control characters (0x00-0x1F, 0x7F) and ANSI escape sequences with underscores. It is applied to all user-supplied values in the log output - title, detail, parameter keys, and parameter values. Structured fields like status code, instance URI, and type URI are not sanitized since they are already validated or type-safe.

The ANSI sequence pattern is ordered before the single-character control class in the regex alternation so that a full sequence like \`ESC[31m\` is replaced as one unit rather than leaving the \`[31m\` suffix behind.

Closes #663