### PR TITLE
Skip stack trace capture in HttpProblem and guard ExceptionMapperBase against toProblem failures

### DIFF
--- a/runtime/src/main/java/io/quarkiverse/httpproblem/ExceptionMapperBase.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/ExceptionMapperBase.java
@@ -7,10 +7,14 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 import jakarta.ws.rs.ext.ExceptionMapper;
 
+import org.jboss.logging.Logger;
+
 import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 import io.quarkiverse.httpproblem.postprocessing.ProblemContext;
 
 public abstract class ExceptionMapperBase<E extends Throwable> implements ExceptionMapper<E> {
+
+    private static final Logger LOG = Logger.getLogger(ExceptionMapperBase.class);
 
     private PostProcessorsRegistry postProcessorsRegistry;
 
@@ -28,7 +32,22 @@ public abstract class ExceptionMapperBase<E extends Throwable> implements Except
     public final Response toResponse(E exception) {
         Objects.requireNonNull(postProcessorsRegistry,
                 "PostProcessorsRegistry not injected — mapper must be instantiated via CDI");
-        HttpProblem problem = toProblem(exception);
+
+        HttpProblem problem;
+        try {
+            problem = toProblem(exception);
+        } catch (Exception e) {
+            LOG.errorf(e, "toProblem() failed for %s, falling back to generic 500",
+                    exception.getClass().getName());
+            problem = HttpProblem.valueOf(Response.Status.INTERNAL_SERVER_ERROR);
+        }
+
+        if (problem == null) {
+            LOG.errorf("toProblem() returned null for %s, falling back to generic 500",
+                    exception.getClass().getName());
+            problem = HttpProblem.valueOf(Response.Status.INTERNAL_SERVER_ERROR);
+        }
+
         ProblemContext context = ProblemContext.of(exception, uriInfo);
         HttpProblem finalProblem = postProcessorsRegistry.applyPostProcessing(problem, context);
         return finalProblem.toResponse();

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/HttpProblem.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/HttpProblem.java
@@ -59,6 +59,11 @@ public class HttpProblem extends RuntimeException {
         this.headers = Collections.unmodifiableMap(Optional.ofNullable(builder.headers).orElseGet(LinkedHashMap::new));
     }
 
+    @Override
+    public synchronized Throwable fillInStackTrace() {
+        return this;
+    }
+
     private static String createMessage(String title, String detail) {
         return Stream.of(title, detail)
                 .filter(Objects::nonNull)

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/ExceptionMapperBaseTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/ExceptionMapperBaseTest.java
@@ -1,0 +1,59 @@
+package io.quarkiverse.httpproblem;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import jakarta.ws.rs.core.Response;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
+
+class ExceptionMapperBaseTest {
+
+    PostProcessorsRegistry registry = new PostProcessorsRegistry(List.of());
+
+    @Test
+    void shouldFallBackToGeneric500WhenToProblemThrows() {
+        ExceptionMapperBase<RuntimeException> mapper = new ExceptionMapperBase<>(registry) {
+            @Override
+            protected HttpProblem toProblem(RuntimeException exception) {
+                throw new IllegalStateException("mapper bug");
+            }
+        };
+
+        Response response = mapper.toResponse(new RuntimeException("original"));
+
+        assertThat(response.getStatus()).isEqualTo(500);
+    }
+
+    @Test
+    void shouldFallBackToGeneric500WhenToProblemReturnsNull() {
+        ExceptionMapperBase<RuntimeException> mapper = new ExceptionMapperBase<>(registry) {
+            @Override
+            protected HttpProblem toProblem(RuntimeException exception) {
+                return null;
+            }
+        };
+
+        Response response = mapper.toResponse(new RuntimeException("original"));
+
+        assertThat(response.getStatus()).isEqualTo(500);
+    }
+
+    @Test
+    void shouldProcessNormallyWhenToProblemSucceeds() {
+        ExceptionMapperBase<RuntimeException> mapper = new ExceptionMapperBase<>(registry) {
+            @Override
+            protected HttpProblem toProblem(RuntimeException exception) {
+                return HttpProblem.valueOf(Response.Status.BAD_REQUEST);
+            }
+        };
+
+        Response response = mapper.toResponse(new RuntimeException("bad input"));
+
+        assertThat(response.getStatus()).isEqualTo(400);
+    }
+
+}

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/HttpProblemTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/HttpProblemTest.java
@@ -50,4 +50,10 @@ class HttpProblemTest {
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
+    @Test
+    void shouldNotCaptureStackTrace() {
+        HttpProblem problem = HttpProblem.valueOf(Response.Status.BAD_REQUEST);
+        assertThat(problem.getStackTrace()).isEmpty();
+    }
+
 }


### PR DESCRIPTION
Closes #669
Closes #670

HttpProblem extends RuntimeException but is used as a structured error container, not for diagnostics. Every construction was capturing a full stack trace - wasted CPU, especially for high-volume 4xx responses. Overriding fillInStackTrace() eliminates this overhead (the existing JMH benchmark can measure the improvement).

Separately, ExceptionMapperBase.toResponse() had no protection if a subclass's toProblem() threw an exception or returned null. The original mapped problem would be lost and the user would get an uncontrolled error instead of a proper application/problem+json response. Now the method catches exceptions and handles null by falling back to a generic 500 problem, logging the failure at ERROR level.