### PR TITLE
Log failures that were previously swallowed silently

### DIFF
--- a/runtime/src/main/java/io/quarkiverse/httpproblem/InstanceUtils.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/InstanceUtils.java
@@ -3,7 +3,11 @@ package io.quarkiverse.httpproblem;
 import java.net.URI;
 import java.net.URISyntaxException;
 
+import org.jboss.logging.Logger;
+
 public final class InstanceUtils {
+
+    private static final Logger LOG = Logger.getLogger(InstanceUtils.class);
 
     public static URI pathToInstance(String path) {
         if (path == null) {
@@ -12,6 +16,7 @@ public final class InstanceUtils {
         try {
             return new URI(null, null, path, null);
         } catch (URISyntaxException e) {
+            LOG.warnf("Could not convert path to URI instance: %s", path);
             return null;
         }
     }

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/InstanceUtils.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/InstanceUtils.java
@@ -16,7 +16,7 @@ public final class InstanceUtils {
         try {
             return new URI(null, null, path, null);
         } catch (URISyntaxException e) {
-            LOG.warnf("Could not convert path to URI instance: %s", path);
+            LOG.warnf(e, "Could not convert path to URI instance: %s", path);
             return null;
         }
     }

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/security/HttpUnauthorizedUtils.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/security/HttpUnauthorizedUtils.java
@@ -4,6 +4,8 @@ import static jakarta.ws.rs.core.Response.Status.UNAUTHORIZED;
 
 import jakarta.ws.rs.core.Response;
 
+import org.jboss.logging.Logger;
+
 import io.quarkiverse.httpproblem.HttpProblem;
 import io.quarkus.vertx.http.runtime.security.ChallengeData;
 import io.quarkus.vertx.http.runtime.security.HttpAuthenticator;
@@ -11,6 +13,8 @@ import io.smallrye.mutiny.Uni;
 import io.vertx.ext.web.RoutingContext;
 
 final class HttpUnauthorizedUtils {
+
+    private static final Logger LOG = Logger.getLogger(HttpUnauthorizedUtils.class);
 
     static Uni<HttpProblem> toProblem(RoutingContext routingContext, Exception exception) {
         return extractChallenge(routingContext)
@@ -53,6 +57,8 @@ final class HttpUnauthorizedUtils {
             return Uni.createFrom().nullItem();
         }
         return authenticator.getChallenge(routingContext)
+                .onFailure()
+                .invoke(failure -> LOG.warnf(failure, "Failed to retrieve authentication challenge"))
                 .onFailure()
                 .recoverWithUni(Uni.createFrom().nullItem());
     }

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/security/HttpUnauthorizedUtilsTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/security/HttpUnauthorizedUtilsTest.java
@@ -56,6 +56,22 @@ class HttpUnauthorizedUtilsTest {
         assertThat(problem.getDetail()).isNull();
     }
 
+    @Test
+    void shouldFallBackToDefaultUnauthorizedWhenAuthenticatorFails() {
+        RoutingContext routingContext = mock(RoutingContext.class);
+        HttpAuthenticator authenticator = mock(HttpAuthenticator.class);
+        when(routingContext.get(HttpAuthenticator.class.getName())).thenReturn(authenticator);
+        when(authenticator.getChallenge(any(RoutingContext.class)))
+                .thenReturn(Uni.createFrom().failure(new RuntimeException("OIDC timeout")));
+
+        HttpProblem problem = HttpUnauthorizedUtils.toProblem(routingContext, new RuntimeException("auth failed"))
+                .await().atMost(Duration.ofSeconds(5));
+
+        assertThat(problem.getStatusCode()).isEqualTo(401);
+        assertThat(problem.getTitle()).isEqualTo("Unauthorized");
+        assertThat(problem.getDetail()).isEqualTo("auth failed");
+    }
+
     private static RoutingContext routingContextReturningChallenge(int challengeStatusCode) {
         return routingContextReturningChallenge(new ChallengeData(challengeStatusCode));
     }


### PR DESCRIPTION
Closes #671
Closes #672

Two places in the codebase catch exceptions and silently return null, making failures impossible to diagnose:

- HttpUnauthorizedUtils.extractChallenge() converted any authenticator failure (misconfigured OIDC, timeouts, NPEs) into a null challenge with no logging. The downstream code handles null gracefully by building a default 401 problem, but the root cause of the failure was invisible. Now logs at WARN with the exception before recovering.

- InstanceUtils.pathToInstance() caught URISyntaxException and returned null silently. Now logs the invalid path at WARN so missing instance fields can be traced to their cause.