### PR TITLE
Reject null field and message in Violation constructor

### DIFF
--- a/runtime/src/main/java/io/quarkiverse/httpproblem/validation/Violation.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/validation/Violation.java
@@ -1,5 +1,7 @@
 package io.quarkiverse.httpproblem.validation;
 
+import java.util.Objects;
+
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Schema(name = "Violation", description = "Validation constraint violation details")
@@ -42,9 +44,9 @@ public final class Violation {
     public final String message;
 
     private Violation(String field, String in, String message) {
-        this.field = field;
-        this.in = in;
-        this.message = message;
+        this.field = Objects.requireNonNull(field, "field must not be null");
+        this.in = Objects.requireNonNull(in, "in must not be null");
+        this.message = Objects.requireNonNull(message, "message must not be null");
     }
 
     @Override

--- a/runtime/src/test/java/io/quarkiverse/httpproblem/validation/ViolationTest.java
+++ b/runtime/src/test/java/io/quarkiverse/httpproblem/validation/ViolationTest.java
@@ -1,0 +1,23 @@
+package io.quarkiverse.httpproblem.validation;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class ViolationTest {
+
+    @Test
+    void shouldRejectNullField() {
+        assertThatThrownBy(() -> Violation.In.body.field(null).message("required"))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("field");
+    }
+
+    @Test
+    void shouldRejectNullMessage() {
+        assertThatThrownBy(() -> Violation.In.body.field("email").message(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("message");
+    }
+
+}


### PR DESCRIPTION
Closes #673

Violation's constructor silently accepted null arguments - In.body.field(null).message(null) would construct an invalid instance that fails unpredictably downstream during serialization. Now fails fast with a clear NullPointerException.

The equals/hashCode concern from the original review is better addressed by converting to records in a future breaking change, as discussed in the PR comments.