### PR TITLE
Use BuildProducer instead of returning null from setupLogging build step

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/httpproblem/deployment/ProblemProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/httpproblem/deployment/ProblemProcessor.java
@@ -256,22 +256,23 @@ public class ProblemProcessor {
 
     @Record(STATIC_INIT)
     @BuildStep
-    SyntheticBeanBuildItem setupLogging(ProblemRecorder recorder, ProblemBuildConfig config) {
+    void setupLogging(ProblemRecorder recorder, ProblemBuildConfig config,
+            BuildProducer<SyntheticBeanBuildItem> syntheticBeans) {
         ProblemBuildConfig.LoggingConfig logging = config.logging();
         if (!logging.enabled()) {
-            return null;
+            return;
         }
 
         Map<String, ProblemLogLevel> levels = new LinkedHashMap<>(ProblemLoggingConfig.DEFAULT_LEVELS);
         levels.putAll(logging.level());
 
         RuntimeValue<ProblemLogger> runtimeValue = recorder.createProblemLogger(levels, logging.includeStackTrace());
-        return SyntheticBeanBuildItem.configure(ProblemLogger.class)
+        syntheticBeans.produce(SyntheticBeanBuildItem.configure(ProblemLogger.class)
                 .scope(Singleton.class)
                 .addType(ProblemPostProcessor.class)
                 .runtimeValue(runtimeValue)
                 .unremovable()
-                .done();
+                .done());
     }
 
     @BuildStep


### PR DESCRIPTION
Closes #674

The setupLogging @BuildStep method returned null when logging was disabled. Returning null from a build step that declares a return type is a Quarkus anti-pattern - downstream build steps that consume SyntheticBeanBuildItem may receive the null and fail with an unhelpful NPE.

Switches to the idiomatic BuildProducer<SyntheticBeanBuildItem> parameter pattern and conditionally calls produce() only when logging is enabled. When disabled, the method simply returns without producing anything.