### PR TITLE
Add Dev UI pages and Dev MCP tools for the HTTP Problem extension

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -15,7 +15,10 @@
         <dependency>
             <groupId>io.quarkiverse.httpproblem</groupId>
             <artifactId>quarkus-http-problem</artifactId>
-            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.httpproblem</groupId>
+            <artifactId>quarkus-http-problem-dev</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -44,6 +47,10 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-openapi-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devui-deployment-spi</artifactId>
         </dependency>
 
         <dependency>

--- a/deployment/src/main/java/io/quarkiverse/httpproblem/deployment/ProblemProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/httpproblem/deployment/ProblemProcessor.java
@@ -16,6 +16,8 @@ import org.eclipse.microprofile.openapi.OASFilter;
 
 import io.quarkiverse.httpproblem.DetailSanitizer;
 import io.quarkiverse.httpproblem.ProblemRuntimeFixedConfig;
+import io.quarkiverse.httpproblem.deployment.devui.ExceptionMapperInfo;
+import io.quarkiverse.httpproblem.devui.ProblemJsonRpcService;
 import io.quarkiverse.httpproblem.postprocessing.MdcPropertiesInjector;
 import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
 import io.quarkiverse.httpproblem.postprocessing.ProblemDefaultsProvider;
@@ -29,12 +31,16 @@ import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
+import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
+import io.quarkus.devui.spi.page.CardPageBuildItem;
+import io.quarkus.devui.spi.page.Page;
 import io.quarkus.jsonb.spi.JsonbDeserializerBuildItem;
 import io.quarkus.jsonb.spi.JsonbSerializerBuildItem;
 import io.quarkus.resteasy.common.spi.ResteasyJaxrsProviderBuildItem;
@@ -277,5 +283,49 @@ public class ProblemProcessor {
     @BuildStep
     UnremovableBeanBuildItem markPostProcessorsUnremovable() {
         return UnremovableBeanBuildItem.beanTypes(ProblemPostProcessor.class);
+    }
+
+    @BuildStep(onlyIf = IsDevelopment.class)
+    CardPageBuildItem createDevUIPages(ProblemBuildConfig config, Capabilities capabilities) {
+        CardPageBuildItem card = new CardPageBuildItem();
+
+        List<ExceptionMapperInfo> mapperInfos = neededExceptionMappers(config, capabilities).stream()
+                .map(m -> new ExceptionMapperInfo(
+                        shortName(m.exceptionClassName),
+                        shortName(m.mapperClassName),
+                        "Active"))
+                .collect(Collectors.toList());
+
+        card.addBuildTimeData("mappers", mapperInfos,
+                "List of active HTTP Problem exception mappers with their exception type and status");
+
+        card.addPage(Page.tableDataPageBuilder("Exception Mappers")
+                .icon("font-awesome-solid:map")
+                .showColumn("exception")
+                .showColumn("mapper")
+                .showColumn("status")
+                .buildTimeDataKey("mappers"));
+
+        card.addPage(Page.webComponentPageBuilder()
+                .title("Post Processors")
+                .icon("font-awesome-solid:layer-group")
+                .componentLink("qwc-http-problem-processors.js"));
+
+        card.addPage(Page.webComponentPageBuilder()
+                .title("Test")
+                .icon("font-awesome-solid:flask")
+                .componentLink("qwc-http-problem-test.js"));
+
+        return card;
+    }
+
+    @BuildStep
+    JsonRPCProvidersBuildItem registerJsonRpcService() {
+        return new JsonRPCProvidersBuildItem(ProblemJsonRpcService.class);
+    }
+
+    private static String shortName(String fqcn) {
+        int lastDot = fqcn.lastIndexOf('.');
+        return lastDot >= 0 ? fqcn.substring(lastDot + 1) : fqcn;
     }
 }

--- a/deployment/src/main/java/io/quarkiverse/httpproblem/deployment/devui/ExceptionMapperInfo.java
+++ b/deployment/src/main/java/io/quarkiverse/httpproblem/deployment/devui/ExceptionMapperInfo.java
@@ -1,0 +1,27 @@
+package io.quarkiverse.httpproblem.deployment.devui;
+
+public final class ExceptionMapperInfo {
+
+    public final String exception;
+    public final String mapper;
+    public final String status;
+
+    public ExceptionMapperInfo(String exception, String mapper, String status) {
+        this.exception = exception;
+        this.mapper = mapper;
+        this.status = status;
+    }
+
+    public String getException() {
+        return exception;
+    }
+
+    public String getMapper() {
+        return mapper;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+}

--- a/deployment/src/main/resources/dev-ui/qwc-http-problem-processors.js
+++ b/deployment/src/main/resources/dev-ui/qwc-http-problem-processors.js
@@ -1,0 +1,84 @@
+import { LitElement, html, css } from 'lit';
+import { JsonRpc } from 'jsonrpc';
+
+export class QwcHttpProblemProcessors extends LitElement {
+
+    static styles = css`
+        .processors-table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+        .processors-table th, .processors-table td {
+            padding: 8px 12px;
+            text-align: left;
+            border-bottom: 1px solid var(--lumo-contrast-10pct);
+        }
+        .processors-table th {
+            color: var(--lumo-secondary-text-color);
+            font-weight: 600;
+        }
+        .order-badge {
+            display: inline-block;
+            background: var(--lumo-primary-color-10pct);
+            color: var(--lumo-primary-text-color);
+            padding: 2px 8px;
+            border-radius: 4px;
+            font-size: 0.85em;
+        }
+    `;
+
+    static properties = {
+        _processors: { state: true },
+        _loading: { state: true }
+    };
+
+    constructor() {
+        super();
+        this._processors = [];
+        this._loading = true;
+        this.jsonRpc = new JsonRpc(this);
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        this.jsonRpc.getPostProcessors().then(response => {
+            this._processors = response.result;
+            this._loading = false;
+        });
+    }
+
+    render() {
+        if (this._loading) {
+            return html`<p>Loading post-processors...</p>`;
+        }
+
+        if (this._processors.length === 0) {
+            return html`<p>No post-processors registered.</p>`;
+        }
+
+        return html`
+            <table class="processors-table">
+                <thead>
+                    <tr>
+                        <th>Order</th>
+                        <th>Processor</th>
+                        <th>Class</th>
+                        <th>Priority</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    ${this._processors.map((p, i) => html`
+                        <tr>
+                            <td><span class="order-badge">${i + 1}</span></td>
+                            <td>${p.name}</td>
+                            <td><code>${p.className}</code></td>
+                            <td>${p.priority}</td>
+                        </tr>
+                    `)}
+                </tbody>
+            </table>
+        `;
+    }
+}
+
+customElements.define('qwc-http-problem-processors', QwcHttpProblemProcessors);

--- a/deployment/src/main/resources/dev-ui/qwc-http-problem-test.js
+++ b/deployment/src/main/resources/dev-ui/qwc-http-problem-test.js
@@ -1,0 +1,124 @@
+import { LitElement, html, css } from 'lit';
+import { JsonRpc } from 'jsonrpc';
+
+export class QwcHttpProblemTest extends LitElement {
+
+    static styles = css`
+        .test-form {
+            display: flex;
+            gap: 12px;
+            align-items: flex-end;
+            margin-bottom: 16px;
+        }
+        .field {
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+        }
+        .field label {
+            font-size: 0.85em;
+            color: var(--lumo-secondary-text-color);
+        }
+        .field input {
+            padding: 6px 10px;
+            border: 1px solid var(--lumo-contrast-20pct);
+            border-radius: 4px;
+            background: var(--lumo-base-color);
+            color: var(--lumo-body-text-color);
+        }
+        .field input:focus {
+            outline: 2px solid var(--lumo-primary-color);
+            border-color: transparent;
+        }
+        button {
+            padding: 6px 16px;
+            background: var(--lumo-primary-color);
+            color: var(--lumo-primary-contrast-color);
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+        button:hover {
+            opacity: 0.9;
+        }
+        button:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+        }
+        .result {
+            background: var(--lumo-contrast-5pct);
+            border-radius: 6px;
+            padding: 16px;
+        }
+        .result pre {
+            margin: 0;
+            white-space: pre-wrap;
+            word-break: break-word;
+            color: var(--lumo-body-text-color);
+            font-family: monospace;
+        }
+        .result-label {
+            font-size: 0.85em;
+            color: var(--lumo-secondary-text-color);
+            margin-bottom: 8px;
+        }
+    `;
+
+    static properties = {
+        _statusCode: { state: true },
+        _detail: { state: true },
+        _result: { state: true },
+        _loading: { state: true }
+    };
+
+    constructor() {
+        super();
+        this._statusCode = 500;
+        this._detail = '';
+        this._result = null;
+        this._loading = false;
+        this.jsonRpc = new JsonRpc(this);
+    }
+
+    _test() {
+        this._loading = true;
+        this.jsonRpc.testProblem({
+            statusCode: parseInt(this._statusCode),
+            detail: this._detail || null
+        }).then(response => {
+            this._result = response.result;
+            this._loading = false;
+        });
+    }
+
+    render() {
+        return html`
+            <div class="test-form">
+                <div class="field">
+                    <label>Status Code</label>
+                    <input type="number" min="100" max="599"
+                        .value="${this._statusCode}"
+                        @input="${e => this._statusCode = e.target.value}">
+                </div>
+                <div class="field">
+                    <label>Detail (optional)</label>
+                    <input type="text" placeholder="e.g. Resource not found"
+                        .value="${this._detail}"
+                        @input="${e => this._detail = e.target.value}">
+                </div>
+                <button @click="${this._test}" ?disabled="${this._loading}">
+                    ${this._loading ? 'Testing...' : 'Test'}
+                </button>
+            </div>
+
+            ${this._result ? html`
+                <div class="result">
+                    <div class="result-label">Response (application/problem+json)</div>
+                    <pre>${JSON.stringify(this._result, null, 2)}</pre>
+                </div>
+            ` : ''}
+        `;
+    }
+}
+
+customElements.define('qwc-http-problem-test', QwcHttpProblemTest);

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
 
     <modules>
         <module>runtime</module>
+        <module>runtime-dev</module>
         <module>deployment</module>
         <module>integration-test</module>
     </modules>
@@ -61,6 +62,17 @@
                 <groupId>org.zalando</groupId>
                 <artifactId>problem</artifactId>
                 <version>${zalando-problem.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.quarkiverse.httpproblem</groupId>
+                <artifactId>quarkus-http-problem</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkiverse.httpproblem</groupId>
+                <artifactId>quarkus-http-problem-dev</artifactId>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>

--- a/runtime-dev/pom.xml
+++ b/runtime-dev/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkiverse.httpproblem</groupId>
+        <artifactId>quarkus-http-problem-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-http-problem-dev</artifactId>
+    <name>Quarkus - HTTP-Problem - Runtime Dev mode</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkiverse.httpproblem</groupId>
+            <artifactId>quarkus-http-problem</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${quarkus.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>de.thetaphi</groupId>
+                <artifactId>forbiddenapis</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/runtime-dev/src/main/java/io/quarkiverse/httpproblem/devui/ProblemJsonRpcService.java
+++ b/runtime-dev/src/main/java/io/quarkiverse/httpproblem/devui/ProblemJsonRpcService.java
@@ -1,0 +1,86 @@
+package io.quarkiverse.httpproblem.devui;
+
+import java.net.URI;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
+
+import io.quarkiverse.httpproblem.HttpProblem;
+import io.quarkiverse.httpproblem.postprocessing.PostProcessorsRegistry;
+import io.quarkiverse.httpproblem.postprocessing.ProblemContext;
+import io.quarkiverse.httpproblem.postprocessing.ProblemPostProcessor;
+import io.quarkus.runtime.annotations.JsonRpcDescription;
+
+public class ProblemJsonRpcService {
+
+    @Inject
+    PostProcessorsRegistry postProcessorsRegistry;
+
+    @JsonRpcDescription("List active post-processors in the HTTP Problem pipeline with their execution order and priority")
+    public List<Map<String, Object>> getPostProcessors() {
+        return postProcessorsRegistry.getProcessors().stream()
+                .map(this::processorToMap)
+                .collect(Collectors.toList());
+    }
+
+    @JsonRpcDescription("Generate a test HTTP Problem response for a given status code, running it through the full post-processor pipeline")
+    public Map<String, Object> testProblem(
+            @JsonRpcDescription("HTTP status code (e.g. 404, 500)") int statusCode,
+            @JsonRpcDescription("Optional detail message for the problem") String detail) {
+
+        HttpProblem.Builder builder = HttpProblem.builder().withStatus(statusCode);
+
+        Response.Status status = Response.Status.fromStatusCode(statusCode);
+        if (status != null) {
+            builder.withTitle(status.getReasonPhrase());
+        }
+
+        if (detail != null && !detail.isBlank()) {
+            builder.withDetail(detail);
+        }
+
+        HttpProblem problem = builder.build();
+        ProblemContext context = ProblemContext.of(new RuntimeException("Dev UI test"), "/dev-ui/test");
+        HttpProblem processed = postProcessorsRegistry.applyPostProcessing(problem, context);
+
+        return problemToMap(processed);
+    }
+
+    private Map<String, Object> processorToMap(ProblemPostProcessor processor) {
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("name", processor.getClass().getSimpleName());
+        map.put("className", processor.getClass().getName());
+        map.put("priority", processor.priority());
+        return map;
+    }
+
+    private Map<String, Object> problemToMap(HttpProblem problem) {
+        Map<String, Object> map = new LinkedHashMap<>();
+        URI type = problem.getType();
+        if (type != null) {
+            map.put("type", type.toString());
+        }
+        map.put("status", problem.getStatusCode());
+        String title = problem.getTitle();
+        if (title != null) {
+            map.put("title", title);
+        }
+        String detail = problem.getDetail();
+        if (detail != null) {
+            map.put("detail", detail);
+        }
+        URI instance = problem.getInstance();
+        if (instance != null) {
+            map.put("instance", instance.toString());
+        }
+        if (!problem.getParameters().isEmpty()) {
+            map.putAll(problem.getParameters());
+        }
+        return map;
+    }
+
+}

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -114,6 +114,9 @@
                         <configuration>
                             <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}
                             </deployment>
+                            <conditionalDevDependencies>
+                                <artifact>${project.groupId}:${project.artifactId}-dev:${project.version}</artifact>
+                            </conditionalDevDependencies>
                         </configuration>
                         <goals>
                             <goal>extension-descriptor</goal>

--- a/runtime/src/main/java/io/quarkiverse/httpproblem/postprocessing/PostProcessorsRegistry.java
+++ b/runtime/src/main/java/io/quarkiverse/httpproblem/postprocessing/PostProcessorsRegistry.java
@@ -34,6 +34,10 @@ public class PostProcessorsRegistry {
                 .toList();
     }
 
+    public List<ProblemPostProcessor> getProcessors() {
+        return processors;
+    }
+
     public HttpProblem applyPostProcessing(HttpProblem problem, ProblemContext context) {
         HttpProblem finalProblem = problem;
         for (ProblemPostProcessor processor : processors) {


### PR DESCRIPTION
Closes #675

Adds a Dev UI card with four pages that make the extension's state visible during development:

<img width="244" height="274" alt="http-problem-card" src="https://github.com/user-attachments/assets/aa09e155-af5a-49ca-acfc-799012cc8be3" />

<img width="1907" height="722" alt="http-problem-exception-mappers" src="https://github.com/user-attachments/assets/082ec742-3b26-4c99-8593-f2c1d89a0498" />

<img width="1907" height="722" alt="http-problem-post-processors" src="https://github.com/user-attachments/assets/d8a7ac7b-b3f5-433e-9205-5e28bcd8dd1f" />

<img width="1907" height="722" alt="http-problem-test" src="https://github.com/user-attachments/assets/250a593e-3426-4d36-b5e7-c0cfe8f6a986" />


- **Exception Mappers** - table of all active mappers showing which exception types they handle
- **Post Processors** - runtime view of the ordered post-processor pipeline with class names and priorities, fetched via JSON-RPC
- **Test** - interactive form to generate a test problem+json response for any status code, run through the full post-processor pipeline

The two JSON-RPC methods (getPostProcessors, testProblem) are annotated with @JsonRpcDescription so they are also exposed as Dev MCP tools for AI coding agents.